### PR TITLE
feat: Add license update page

### DIFF
--- a/license-update.mdx
+++ b/license-update.mdx
@@ -12,4 +12,4 @@ For larger-scale commercial developers, there's a clear path to supplemental lic
 
 These updates make it easier for everyone to build confidently on stable infrastructure.
 
-See the individual SDKs' READMEs and LICENSEs for more details.
+See the individual SDKs' READMEs and LICENSEs (e.g., [walletconnect-monorepo](https://github.com/WalletConnect/walletconnect-monorepo)) for more details.


### PR DESCRIPTION
Create a standalone license update page that explains the WalletConnect Community License. This page is not included in navigation and will be accessible directly via URL.

See https://test-walletconnect-add-license-update-page.mintlify.app/license-update