### PR TITLE
docs: add Canton chain support specification

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -60,7 +60,8 @@
                                   "wallet-sdk/chain-support/stacks",
                                   "wallet-sdk/chain-support/ton",
                                   "wallet-sdk/chain-support/tron",
-                                  "wallet-sdk/chain-support/adi"
+                                  "wallet-sdk/chain-support/adi",
+                                  "wallet-sdk/chain-support/canton"
                                 ]
               },
               {

--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -19,7 +19,7 @@ dApps should **not** hardcode specific chain IDs in the session proposal. Instea
 
 ```typescript  theme={null}
 const CANTON_WC_METHODS = [
-    'prepareSignExecute',
+    'canton_prepareSignExecute',
     'listAccounts',
     'getPrimaryAccount',
     'getActiveNetwork',
@@ -42,7 +42,7 @@ Read-only methods are auto-approved by the wallet. Methods that mutate the ledge
 | `getActiveNetwork`   | Auto-approve |
 | `status`             | Auto-approve |
 | `ledgerApi`          | Auto-approve |
-| `prepareSignExecute` | Manual       |
+| `canton_prepareSignExecute` | Manual       |
 | `signMessage`        | Manual       |
 
 ## Method Name Mapping (dApp SDK)
@@ -51,14 +51,14 @@ The dApp SDK's `WalletConnectTransport` maps SDK method names before sending ove
 
 | SDK method               | WC method (on the wire)  |
 | ------------------------ | ------------------------ |
-| `prepareExecute`         | `prepareSignExecute`     |
-| `prepareExecuteAndWait`  | `prepareSignExecute`     |
+| `prepareExecute`         | `canton_prepareSignExecute`     |
+| `prepareExecuteAndWait`  | `canton_prepareSignExecute`     |
 
 All other methods (`listAccounts`, `status`, `ledgerApi`, etc.) are sent as-is. Both SDK methods resolve with the same response — over WalletConnect, every submission blocks until the transaction completes.
 
 ## RPC Methods
 
-### prepareSignExecute
+### canton_prepareSignExecute
 
 Prepare, sign, and execute a Canton ledger transaction. This is the primary method for submitting commands that mutate ledger state. The wallet performs the full prepare → sign → execute cycle and responds when the transaction is complete.
 
@@ -66,7 +66,7 @@ Prepare, sign, and execute a Canton ledger transaction. This is the primary meth
 
 ```typescript  theme={null}
 interface PrepareSignExecuteRequest {
-    method: 'prepareSignExecute';
+    method: 'canton_prepareSignExecute';
     params: PrepareParams;
 }
 
@@ -92,7 +92,7 @@ interface PrepareParams {
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "prepareSignExecute",
+        "method": "canton_prepareSignExecute",
         "params": {
             "commands": {
                 "0": {
@@ -560,7 +560,7 @@ The wallet builds approved namespaces including the CAIP-10 account with the URL
     "canton": {
         "chains": ["canton:devnet"],
         "accounts": ["canton:devnet:operator%3A%3A1220abc..."],
-        "methods": ["prepareSignExecute", "listAccounts", "getPrimaryAccount", "getActiveNetwork", "status", "ledgerApi", "signMessage"],
+        "methods": ["canton_prepareSignExecute", "listAccounts", "getPrimaryAccount", "getActiveNetwork", "status", "ledgerApi", "signMessage"],
         "events": ["accountsChanged", "statusChanged", "chainChanged"]
     }
 }
@@ -581,5 +581,5 @@ The wallet builds approved namespaces including the CAIP-10 account with the URL
 - Canton uses Ed25519 signing for transaction authentication.
 - The `ledgerApi` method acts as a transparent proxy — the wallet handles authentication with the Canton Ledger API. Only `GET` and `POST` are supported; other HTTP methods will return a `5001` error.
 - Party IDs in CAIP-10 accounts are URL-encoded (e.g. `operator::1220abc...` becomes `operator%3A%3A1220abc...`).
-- The `prepareSignExecute` method always performs the full prepare → sign → execute cycle synchronously, responding only when the transaction is complete.
+- The `canton_prepareSignExecute` method always performs the full prepare → sign → execute cycle synchronously, responding only when the transaction is complete.
 - The WC session `chainId` (e.g. `canton:devnet`) may differ from the `networkId` in wallet/network records (e.g. `canton:production`). The `chainId` identifies the chain at pairing time, while `networkId` reflects the wallet's internal network configuration.

--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -343,7 +343,8 @@ Check the wallet's connectivity to the Canton ledger.
         },
         "network": {
             "networkId": "canton:production",
-            "ledgerApi": "http://127.0.0.1:5003"
+            "ledgerApi": "http://127.0.0.1:5003",
+            "accessToken": "<token>" // optional but recommended
         }
     }
 }

--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -13,19 +13,19 @@ These are the methods that wallets should implement to handle Canton transaction
 
 Unlike most chains, Canton does not have fixed mainnet/testnet identifiers. Network IDs are **operator-defined** — each wallet is configured with one or more networks, and the `network-id` used in CAIP-2 identifiers comes from that configuration.
 
-dApps should **not** hardcode specific chain IDs in the session proposal. Instead, request the `canton` namespace without specifying `chains`, and work with whatever network the wallet provides in the approved session. The network ID and party ID are available directly from the session's `canton.accounts` array as CAIP-10 strings (e.g. `canton:production:operator%3A%3A1220abc...`). For full network details, use [`getActiveNetwork`](#getactivenetwork).
+dApps should **not** hardcode specific chain IDs in the session proposal. Instead, request the `canton` namespace without specifying `chains`, and work with whatever network the wallet provides in the approved session. The network ID and party ID are available directly from the session's `canton.accounts` array as CAIP-10 strings (e.g. `canton:production:operator%3A%3A1220abc...`). For full network details, use [`canton_getActiveNetwork`](#canton_getactivenetwork).
 
 ## Registered Methods & Events
 
 ```typescript  theme={null}
 const CANTON_WC_METHODS = [
     'canton_prepareSignExecute',
-    'listAccounts',
-    'getPrimaryAccount',
-    'getActiveNetwork',
-    'status',
-    'ledgerApi',
-    'signMessage',
+    'canton_listAccounts',
+    'canton_getPrimaryAccount',
+    'canton_getActiveNetwork',
+    'canton_status',
+    'canton_ledgerApi',
+    'canton_signMessage',
 ]
 
 const CANTON_WC_EVENTS = ['accountsChanged', 'statusChanged', 'chainChanged']
@@ -37,13 +37,13 @@ Read-only methods are auto-approved by the wallet. Methods that mutate the ledge
 
 | Method               | Approval     |
 | -------------------- | ------------ |
-| `listAccounts`       | Auto-approve |
-| `getPrimaryAccount`  | Auto-approve |
-| `getActiveNetwork`   | Auto-approve |
-| `status`             | Auto-approve |
-| `ledgerApi`          | Auto-approve |
+| `canton_listAccounts`       | Auto-approve |
+| `canton_getPrimaryAccount`  | Auto-approve |
+| `canton_getActiveNetwork`   | Auto-approve |
+| `canton_status`             | Auto-approve |
+| `canton_ledgerApi`          | Auto-approve |
 | `canton_prepareSignExecute` | Manual       |
-| `signMessage`        | Manual       |
+| `canton_signMessage`        | Manual       |
 
 ## Method Name Mapping (dApp SDK)
 
@@ -51,10 +51,10 @@ The dApp SDK's `WalletConnectTransport` maps SDK method names before sending ove
 
 | SDK method               | WC method (on the wire)  |
 | ------------------------ | ------------------------ |
-| `prepareExecute`         | `canton_prepareSignExecute`     |
-| `prepareExecuteAndWait`  | `canton_prepareSignExecute`     |
+| `canton_prepareExecute`         | `canton_prepareSignExecute`     |
+| `canton_prepareExecuteAndWait`  | `canton_prepareSignExecute`     |
 
-All other methods (`listAccounts`, `status`, `ledgerApi`, etc.) are sent as-is. Both SDK methods resolve with the same response — over WalletConnect, every submission blocks until the transaction completes.
+All other methods (`canton_listAccounts`, `canton_status`, `canton_ledgerApi`, etc.) are sent as-is. Both SDK methods resolve with the same response — over WalletConnect, every submission blocks until the transaction completes.
 
 ## RPC Methods
 
@@ -65,12 +65,12 @@ Prepare, sign, and execute a Canton ledger transaction. This is the primary meth
 #### Request
 
 ```typescript  theme={null}
-interface PrepareSignExecuteRequest {
+interface CantonPrepareSignExecuteRequest {
     method: 'canton_prepareSignExecute';
-    params: PrepareParams;
+    params: CantonPrepareParams;
 }
 
-interface PrepareParams {
+interface CantonPrepareParams {
     commandId?: string;          // auto-generated (UUIDv4) if omitted
     commands?: { [k: string]: unknown };
     actAs?: string[];            // defaults to [primaryWallet.partyId] if omitted
@@ -178,7 +178,7 @@ Wallets support multiple signing backends. The signing provider determines the L
 
 ---
 
-### listAccounts
+### canton_listAccounts
 
 Retrieve all configured wallet accounts.
 
@@ -189,7 +189,7 @@ Retrieve all configured wallet accounts.
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "listAccounts",
+        "method": "canton_listAccounts",
         "params": {}
     }
 }
@@ -238,7 +238,7 @@ interface Wallet {
 
 ---
 
-### getPrimaryAccount
+### canton_getPrimaryAccount
 
 Retrieve the primary wallet account (where `primary === true`).
 
@@ -249,7 +249,7 @@ Retrieve the primary wallet account (where `primary === true`).
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "getPrimaryAccount",
+        "method": "canton_getPrimaryAccount",
         "params": {}
     }
 }
@@ -276,7 +276,7 @@ Retrieve the primary wallet account (where `primary === true`).
 
 ---
 
-### getActiveNetwork
+### canton_getActiveNetwork
 
 Retrieve the currently active network configuration.
 
@@ -287,7 +287,7 @@ Retrieve the currently active network configuration.
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "getActiveNetwork",
+        "method": "canton_getActiveNetwork",
         "params": {}
     }
 }
@@ -308,7 +308,7 @@ Retrieve the currently active network configuration.
 
 ---
 
-### status
+### canton_status
 
 Check the wallet's connectivity to the Canton ledger.
 
@@ -319,7 +319,7 @@ Check the wallet's connectivity to the Canton ledger.
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "status",
+        "method": "canton_status",
         "params": {}
     }
 }
@@ -372,19 +372,19 @@ Check the wallet's connectivity to the Canton ledger.
 
 ---
 
-### ledgerApi
+### canton_ledgerApi
 
 Proxy raw Canton Ledger API requests through the wallet. The wallet authenticates and forwards the request.
 
 #### Request
 
 ```typescript  theme={null}
-interface LedgerApiRequest {
-    method: 'ledgerApi';
-    params: LedgerApiParams;
+interface CantonLedgerApiRequest {
+    method: 'canton_ledgerApi';
+    params: CantonLedgerApiParams;
 }
 
-interface LedgerApiParams {
+interface CantonLedgerApiParams {
     requestMethod: 'GET' | 'POST';
     resource: string;
     body?: string | object;
@@ -398,7 +398,7 @@ interface LedgerApiParams {
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "ledgerApi",
+        "method": "canton_ledgerApi",
         "params": {
             "requestMethod": "POST",
             "resource": "/v2/state/active-contracts",
@@ -439,15 +439,15 @@ The `response` field contains the raw Ledger API JSON response as-is.
 
 ---
 
-### signMessage
+### canton_signMessage
 
 Sign an arbitrary message with the wallet's Ed25519 private key.
 
 #### Request
 
 ```typescript  theme={null}
-interface SignMessageRequest {
-    method: 'signMessage';
+interface CantonSignMessageRequest {
+    method: 'canton_signMessage';
     params: {
         message: string;
     };
@@ -461,7 +461,7 @@ interface SignMessageRequest {
     "topic": "<session-topic>",
     "chainId": "canton:devnet",
     "request": {
-        "method": "signMessage",
+        "method": "canton_signMessage",
         "params": {
             "message": "Please sign this message to verify your identity"
         }
@@ -560,7 +560,7 @@ The wallet builds approved namespaces including the CAIP-10 account with the URL
     "canton": {
         "chains": ["canton:devnet"],
         "accounts": ["canton:devnet:operator%3A%3A1220abc..."],
-        "methods": ["canton_prepareSignExecute", "listAccounts", "getPrimaryAccount", "getActiveNetwork", "status", "ledgerApi", "signMessage"],
+        "methods": ["canton_prepareSignExecute", "canton_listAccounts", "canton_getPrimaryAccount", "canton_getActiveNetwork", "canton_status", "canton_ledgerApi", "canton_signMessage"],
         "events": ["accountsChanged", "statusChanged", "chainChanged"]
     }
 }

--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -1,0 +1,585 @@
+---
+title: Canton
+description: "Overview of the Canton JSON-RPC methods supported by Wallet SDK."
+---
+
+These are the methods that wallets should implement to handle Canton transactions and messages via WalletConnect.
+
+## Network / Chain Information
+
+- **Namespace:** `canton`
+- **CAIP-2:** `canton:<network-id>` (e.g. `canton:devnet`, `canton:production`)
+- **CAIP-10 Account:** `canton:<network-id>:<url-encoded-party-id>` (e.g. `canton:devnet:operator%3A%3A1220abc...`)
+
+Unlike most chains, Canton does not have fixed mainnet/testnet identifiers. Network IDs are **operator-defined** — each wallet is configured with one or more networks, and the `network-id` used in CAIP-2 identifiers comes from that configuration.
+
+dApps should **not** hardcode specific chain IDs in the session proposal. Instead, request the `canton` namespace without specifying `chains`, and work with whatever network the wallet provides in the approved session. The network ID and party ID are available directly from the session's `canton.accounts` array as CAIP-10 strings (e.g. `canton:production:operator%3A%3A1220abc...`). For full network details, use [`getActiveNetwork`](#getactivenetwork).
+
+## Registered Methods & Events
+
+```typescript  theme={null}
+const CANTON_WC_METHODS = [
+    'prepareSignExecute',
+    'listAccounts',
+    'getPrimaryAccount',
+    'getActiveNetwork',
+    'status',
+    'ledgerApi',
+    'signMessage',
+]
+
+const CANTON_WC_EVENTS = ['accountsChanged', 'statusChanged', 'chainChanged']
+```
+
+### Auto-Approve vs Manual-Approve
+
+Read-only methods are auto-approved by the wallet. Methods that mutate the ledger or perform sensitive operations require explicit user approval.
+
+| Method               | Approval     |
+| -------------------- | ------------ |
+| `listAccounts`       | Auto-approve |
+| `getPrimaryAccount`  | Auto-approve |
+| `getActiveNetwork`   | Auto-approve |
+| `status`             | Auto-approve |
+| `ledgerApi`          | Auto-approve |
+| `prepareSignExecute` | Manual       |
+| `signMessage`        | Manual       |
+
+## Method Name Mapping (dApp SDK)
+
+The dApp SDK's `WalletConnectTransport` maps SDK method names before sending over WC:
+
+| SDK method               | WC method (on the wire)  |
+| ------------------------ | ------------------------ |
+| `prepareExecute`         | `prepareSignExecute`     |
+| `prepareExecuteAndWait`  | `prepareSignExecute`     |
+
+All other methods (`listAccounts`, `status`, `ledgerApi`, etc.) are sent as-is. Both SDK methods resolve with the same response — over WalletConnect, every submission blocks until the transaction completes.
+
+## RPC Methods
+
+### prepareSignExecute
+
+Prepare, sign, and execute a Canton ledger transaction. This is the primary method for submitting commands that mutate ledger state. The wallet performs the full prepare → sign → execute cycle and responds when the transaction is complete.
+
+#### Request
+
+```typescript  theme={null}
+interface PrepareSignExecuteRequest {
+    method: 'prepareSignExecute';
+    params: PrepareParams;
+}
+
+interface PrepareParams {
+    commandId?: string;          // auto-generated (UUIDv4) if omitted
+    commands?: { [k: string]: unknown };
+    actAs?: string[];            // defaults to [primaryWallet.partyId] if omitted
+    readAs?: string[];           // defaults to [] if omitted
+    disclosedContracts?: Array<{
+        templateId?: string;
+        contractId?: string;
+        createdEventBlob: string;
+        synchronizerId?: string;
+    }>;
+    packageIdSelectionPreference?: string[];
+}
+```
+
+#### Example Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "prepareSignExecute",
+        "params": {
+            "commands": {
+                "0": {
+                    "ExerciseCommand": {
+                        "templateId": "#<package-id>:Module:Template",
+                        "contractId": "00abcdef...",
+                        "choice": "Transfer",
+                        "choiceArgument": {
+                            "receiver": "bob::1220..."
+                        }
+                    }
+                }
+            },
+            "commandId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+            "actAs": ["operator::1220abc..."],
+            "readAs": [],
+            "disclosedContracts": [
+                {
+                    "templateId": "#<package-id>:Module:Template",
+                    "contractId": "00abcdef...",
+                    "createdEventBlob": "<base64-encoded-blob>",
+                    "synchronizerId": "wallet::1220e7b..."
+                }
+            ],
+            "packageIdSelectionPreference": ["<package-id>"]
+        }
+    }
+}
+```
+
+#### Signing Providers
+
+Wallets support multiple signing backends. The signing provider determines the Ledger API flow used:
+
+| Provider         | Flow                                                                 |
+| ---------------- | -------------------------------------------------------------------- |
+| `participant`    | Single call to `POST /v2/commands/submit-and-wait` (participant signs internally) |
+| `wallet-kernel`  | `POST /v2/interactive-submission/prepare` → local Ed25519 sign → `POST /v2/interactive-submission/execute` |
+| `blockdaemon`    | `POST /v2/interactive-submission/prepare` → sign via Blockdaemon API → `POST /v2/interactive-submission/execute` |
+
+#### Success Response
+
+```json  theme={null}
+{
+    "id": 1234,
+    "jsonrpc": "2.0",
+    "result": {
+        "status": "executed",
+        "commandId": "d290f1ee-...",
+        "payload": {
+            "updateId": "tx-update-id",
+            "completionOffset": 42
+        }
+    }
+}
+```
+
+#### Error Response
+
+```json  theme={null}
+{
+    "id": 1234,
+    "jsonrpc": "2.0",
+    "error": {
+        "code": 5001,
+        "message": "Transaction execution failed: INVALID_ARGUMENT: ..."
+    }
+}
+```
+
+#### User Rejected Response
+
+```json  theme={null}
+{
+    "id": 1234,
+    "jsonrpc": "2.0",
+    "error": {
+        "code": 5000,
+        "message": "User rejected"
+    }
+}
+```
+
+---
+
+### listAccounts
+
+Retrieve all configured wallet accounts.
+
+#### Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "listAccounts",
+        "params": {}
+    }
+}
+```
+
+#### Response
+
+```json  theme={null}
+{
+    "id": 1235,
+    "jsonrpc": "2.0",
+    "result": [
+        {
+            "primary": true,
+            "partyId": "operator::1220abc...",
+            "status": "allocated",
+            "hint": "operator",
+            "publicKey": "<base64-ed25519-pubkey>",
+            "namespace": "1220abc...",
+            "networkId": "canton:production",
+            "signingProviderId": "participant",
+            "disabled": false
+        }
+    ]
+}
+```
+
+#### Wallet Type
+
+```typescript  theme={null}
+interface Wallet {
+    primary: boolean;
+    partyId: string;
+    status: 'initialized' | 'allocated' | 'removed';
+    hint: string;
+    publicKey: string;
+    namespace: string;
+    networkId: string;
+    signingProviderId: string;
+    externalTxId?: string;
+    topologyTransactions?: string;
+    disabled?: boolean;
+    reason?: string;
+}
+```
+
+---
+
+### getPrimaryAccount
+
+Retrieve the primary wallet account (where `primary === true`).
+
+#### Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "getPrimaryAccount",
+        "params": {}
+    }
+}
+```
+
+#### Response
+
+```json  theme={null}
+{
+    "id": 1236,
+    "jsonrpc": "2.0",
+    "result": {
+        "primary": true,
+        "partyId": "operator::1220abc...",
+        "status": "allocated",
+        "hint": "operator",
+        "publicKey": "<base64-ed25519-pubkey>",
+        "namespace": "1220abc...",
+        "networkId": "canton:production",
+        "signingProviderId": "participant"
+    }
+}
+```
+
+---
+
+### getActiveNetwork
+
+Retrieve the currently active network configuration.
+
+#### Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "getActiveNetwork",
+        "params": {}
+    }
+}
+```
+
+#### Response
+
+```json  theme={null}
+{
+    "id": 1237,
+    "jsonrpc": "2.0",
+    "result": {
+        "networkId": "canton:production",
+        "ledgerApi": "http://127.0.0.1:5003"
+    }
+}
+```
+
+---
+
+### status
+
+Check the wallet's connectivity to the Canton ledger.
+
+#### Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "status",
+        "params": {}
+    }
+}
+```
+
+#### Response (ledger reachable)
+
+```json  theme={null}
+{
+    "id": 1238,
+    "jsonrpc": "2.0",
+    "result": {
+        "provider": {
+            "id": "remote-da",
+            "version": "3.4.0",
+            "providerType": "remote"
+        },
+        "connection": {
+            "isConnected": true,
+            "isNetworkConnected": true
+        },
+        "network": {
+            "networkId": "canton:production",
+            "ledgerApi": "http://127.0.0.1:5003"
+        }
+    }
+}
+```
+
+#### Response (ledger unreachable)
+
+```json  theme={null}
+{
+    "id": 1238,
+    "jsonrpc": "2.0",
+    "result": {
+        "provider": {
+            "id": "remote-da",
+            "version": "3.4.0",
+            "providerType": "remote"
+        },
+        "connection": {
+            "isConnected": true,
+            "isNetworkConnected": false,
+            "reason": "Ledger unreachable"
+        }
+    }
+}
+```
+
+---
+
+### ledgerApi
+
+Proxy raw Canton Ledger API requests through the wallet. The wallet authenticates and forwards the request.
+
+#### Request
+
+```typescript  theme={null}
+interface LedgerApiRequest {
+    method: 'ledgerApi';
+    params: LedgerApiParams;
+}
+
+interface LedgerApiParams {
+    requestMethod: 'GET' | 'POST';
+    resource: string;
+    body?: string | object;
+}
+```
+
+#### Example Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "ledgerApi",
+        "params": {
+            "requestMethod": "POST",
+            "resource": "/v2/state/active-contracts",
+            "body": {
+                "filter": {
+                    "filtersByParty": {
+                        "operator::1220abc...": {
+                            "cumulative": {
+                                "templateFilters": []
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+#### Response
+
+```json  theme={null}
+{
+    "id": 1239,
+    "jsonrpc": "2.0",
+    "result": {
+        "response": {
+            "version": "3.4.0",
+            "features": {}
+        }
+    }
+}
+```
+
+<Note>
+The `response` field contains the raw Ledger API JSON response as-is.
+</Note>
+
+---
+
+### signMessage
+
+Sign an arbitrary message with the wallet's Ed25519 private key.
+
+#### Request
+
+```typescript  theme={null}
+interface SignMessageRequest {
+    method: 'signMessage';
+    params: {
+        message: string;
+    };
+}
+```
+
+#### Example Request
+
+```json  theme={null}
+{
+    "topic": "<session-topic>",
+    "chainId": "canton:devnet",
+    "request": {
+        "method": "signMessage",
+        "params": {
+            "message": "Please sign this message to verify your identity"
+        }
+    }
+}
+```
+
+#### Success Response
+
+```json  theme={null}
+{
+    "id": 1240,
+    "jsonrpc": "2.0",
+    "result": {
+        "signature": "<base64-ed25519-signature>",
+        "publicKey": "<base64-ed25519-pubkey>"
+    }
+}
+```
+
+## Events
+
+### accountsChanged
+
+Emitted when wallet accounts are added, removed, or modified.
+
+```json  theme={null}
+{
+    "name": "accountsChanged",
+    "data": [
+        {
+            "primary": true,
+            "partyId": "operator::1220abc...",
+            "status": "allocated",
+            "hint": "operator",
+            "publicKey": "...",
+            "namespace": "1220abc...",
+            "networkId": "canton:production",
+            "signingProviderId": "participant"
+        }
+    ]
+}
+```
+
+### statusChanged
+
+Emitted when the wallet's connectivity status changes.
+
+```json  theme={null}
+{
+    "name": "statusChanged",
+    "data": {
+        "provider": { "id": "remote-da", "providerType": "remote" },
+        "connection": { "isConnected": true, "isNetworkConnected": true },
+        "network": { "networkId": "canton:production" }
+    }
+}
+```
+
+### chainChanged
+
+Emitted when the wallet switches to a different network.
+
+```json  theme={null}
+{
+    "name": "chainChanged",
+    "data": {
+        "chainId": "canton:production"
+    }
+}
+```
+
+## Session Lifecycle
+
+### Pairing
+
+The dApp creates a pairing URI and delivers it to the wallet:
+
+```typescript
+const { uri, approval } = await signClient.connect({
+    optionalNamespaces: {
+        canton: {
+            methods: CANTON_WC_METHODS,
+            events: CANTON_WC_EVENTS,
+        },
+    },
+})
+```
+
+### Session Approval
+
+The wallet builds approved namespaces including the CAIP-10 account with the URL-encoded partyId:
+
+```json  theme={null}
+{
+    "canton": {
+        "chains": ["canton:devnet"],
+        "accounts": ["canton:devnet:operator%3A%3A1220abc..."],
+        "methods": ["prepareSignExecute", "listAccounts", "getPrimaryAccount", "getActiveNetwork", "status", "ledgerApi", "signMessage"],
+        "events": ["accountsChanged", "statusChanged", "chainChanged"]
+    }
+}
+```
+
+## Error Codes
+
+| Code   | Meaning                                   |
+| ------ | ----------------------------------------- |
+| `5000` | User rejected                             |
+| `5001` | Execution / handler error                 |
+| `5100` | Canton namespace not found in proposal    |
+| `6000` | Wallet disconnected                       |
+
+## Notes & Considerations
+
+- All requests and responses comply with JSON-RPC structure (`id`, `jsonrpc`, etc.).
+- Canton uses Ed25519 signing for transaction authentication.
+- The `ledgerApi` method acts as a transparent proxy — the wallet handles authentication with the Canton Ledger API. Only `GET` and `POST` are supported; other HTTP methods will return a `5001` error.
+- Party IDs in CAIP-10 accounts are URL-encoded (e.g. `operator::1220abc...` becomes `operator%3A%3A1220abc...`).
+- The `prepareSignExecute` method always performs the full prepare → sign → execute cycle synchronously, responding only when the transaction is complete.
+- The WC session `chainId` (e.g. `canton:devnet`) may differ from the `networkId` in wallet/network records (e.g. `canton:production`). The `chainId` identifies the chain at pairing time, while `networkId` reflects the wallet's internal network configuration.

--- a/wallet-sdk/chain-support/overview.mdx
+++ b/wallet-sdk/chain-support/overview.mdx
@@ -14,6 +14,7 @@ The Wallet SDK is built to be **chain-agnostic** — it supports integrations ac
 - [TON](/wallet-sdk/chain-support/ton)
 - [Tron](/wallet-sdk/chain-support/tron)
 - [ADI Chain](/wallet-sdk/chain-support/adi)
+- [Canton](/wallet-sdk/chain-support/canton)
 
 ## Adding New Chain Support
 


### PR DESCRIPTION
## Summary

- Add new Canton chain support page at `wallet-sdk/chain-support/canton.mdx` covering the full WalletConnect integration specification
- Register Canton in sidebar navigation (`docs.json`) and ecosystem overview page

## What's Documented

- **Network / Chain Information**: Operator-defined CAIP-2 network IDs (no fixed mainnet/testnet), CAIP-10 account format with URL-encoded party IDs
- **7 RPC Methods** (all prefixed with `canton_`):
  - `canton_prepareSignExecute` — prepare, sign, and execute ledger transactions with multiple signing provider support
  - `canton_listAccounts` — retrieve all configured wallet accounts
  - `canton_getPrimaryAccount` — retrieve the primary wallet account
  - `canton_getActiveNetwork` — discover the active network configuration
  - `canton_status` — check wallet connectivity to the Canton ledger
  - `canton_ledgerApi` — proxy raw Ledger API requests through the wallet
  - `canton_signMessage` — sign arbitrary messages with Ed25519
- **3 Events**: `accountsChanged`, `statusChanged`, `chainChanged`
- **Auto-approve vs manual-approve** classification for read-only vs ledger-mutating methods
- **dApp SDK method mapping** (`canton_prepareExecute` / `canton_prepareExecuteAndWait` → `canton_prepareSignExecute`)
- **Signing providers**: `participant`, `wallet-kernel`, `blockdaemon` with their Ledger API flows
- **Session lifecycle**: Pairing with `optionalNamespaces` (no hardcoded chains), approval with CAIP-10 accounts
- **Error codes**: 5000, 5001, 5100, 6000

## Test plan

- [ ] Run `mint dev` and verify the Canton page renders correctly at `/wallet-sdk/chain-support/canton`
- [ ] Verify sidebar navigation shows Canton under Chain Support
- [ ] Verify overview page links to Canton
- [ ] Check all JSON/TypeScript code blocks render properly
- [ ] Confirm internal anchor links work (e.g. `#canton_getactivenetwork`)