### PR TITLE
docs: add Canton dApp SDK to App SDK overview

### DIFF
--- a/app-sdk/overview.mdx
+++ b/app-sdk/overview.mdx
@@ -82,6 +82,7 @@ In this context, SDKs are pre-packaged developer tools that abstract away the un
 - [**Dynamic**](https://www.dynamic.xyz/) - All-in-one authentication and wallet SDK for web3 apps across mobile and web.
 - [**ConnectKit**](https://family.co/connectkit) - Beautiful React components built for WalletConnect connections.
 - [**RainbowKit**](https://www.rainbowkit.com/) - Customizable wallet connection UI optimized for Ethereum and WalletConnect.
+- [**Canton dApp SDK**](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/sdk/dapp-sdk) - Browser SDK from the [Splice Wallet Kernel](https://github.com/hyperledger-labs/splice-wallet-kernel) for building dApps on the [Canton Network](https://www.canton.network/). Implements the [CIP-103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md) dApp API with multi-transport support (HTTP, `postMessage`) and an EIP-1193-style `window.canton` provider.
 
 These SDKs demonstrate what’s possible with the App SDK as a base layer and how it can be extended to suit your product, stack, and user flow.
 
@@ -96,6 +97,7 @@ Below you can find the chain compatibility for the most popular SDKs built on to
 | **Dynamic**      | EVM, Solana, Bitcoin, Flow, StarkNet, Sui, Cosmos, Algorand, Spark |
 | **ConnectKit**   | EVM                                                |
 | **RainbowKit**   | EVM                                                |
+| **Canton dApp SDK** | Canton Network                                  |
 
 ## Standalone Integration of WalletConnect as an App
 


### PR DESCRIPTION
## Summary

- Adds the [Canton dApp SDK](https://github.com/hyperledger-labs/splice-wallet-kernel/tree/main/sdk/dapp-sdk) to the "Most Popular SDKs built on top of WalletConnect" list in `app-sdk/overview.mdx`.
- Adds a row to the SDK Chain Compatibility table mapping the Canton dApp SDK to the Canton Network.
- Brief description notes that the SDK comes from the [Splice Wallet Kernel](https://github.com/hyperledger-labs/splice-wallet-kernel), implements [CIP-103](https://github.com/canton-foundation/cips/blob/main/cip-0103/cip-0103.md), supports HTTP and `postMessage` transports, and exposes an EIP-1193-style `window.canton` provider.

Complements the existing Canton chain support documentation in `wallet-sdk/chain-support/canton.mdx`.

## Test plan

- [x] Preview the rendered `app-sdk/overview.mdx` page and verify the new SDK list entry and table row render correctly
- [x] Verify all external links resolve (Splice Wallet Kernel repo, Canton Network, CIP-103)

Made with [Cursor](https://cursor.com)