### PR TITLE
docs: clarify canton_ledgerApi response is raw Ledger API JSON

### DIFF
--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -425,7 +425,7 @@ interface CantonLedgerApiParams {
 {
     "id": 1239,
     "jsonrpc": "2.0",
-    "result": {} // raw Ledger API JSON response as-is
+    "result": {}
 }
 ```
 

--- a/wallet-sdk/chain-support/canton.mdx
+++ b/wallet-sdk/chain-support/canton.mdx
@@ -425,17 +425,12 @@ interface CantonLedgerApiParams {
 {
     "id": 1239,
     "jsonrpc": "2.0",
-    "result": {
-        "response": {
-            "version": "3.4.0",
-            "features": {}
-        }
-    }
+    "result": {} // raw Ledger API JSON response as-is
 }
 ```
 
 <Note>
-The `response` field contains the raw Ledger API JSON response as-is.
+The `result` field contains the raw Ledger API JSON response as-is.
 </Note>
 
 ---


### PR DESCRIPTION
## Summary
- Replace the `canton_ledgerApi` example response payload (`version`/`features` object) with a placeholder indicating the `result` field contains the raw Ledger API JSON response as-is
- Update the info note below the example to reference the `result` field instead of a `response` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)